### PR TITLE
Setando ALB como internal

### DIFF
--- a/modules/alb/alb.tf
+++ b/modules/alb/alb.tf
@@ -1,6 +1,7 @@
 resource "aws_alb" "restaurant_alb" {
   name               = "restaurant-alb"
   load_balancer_type = "application"
+  internal = true
   subnets = [
     "${var.aws_subnets.subnet1}",
     "${var.aws_subnets.subnet2}",


### PR DESCRIPTION
Pelo fato de ele estar public facing gerava erro no roteando do API Gateway -> ALB e gerava erro HTTP 503 na requisição.