### PR TITLE
Corrigindo security group errado do ECS service

### DIFF
--- a/modules/ecs/ecs.tf
+++ b/modules/ecs/ecs.tf
@@ -101,7 +101,7 @@ resource "aws_ecs_service" "restaurant_service" {
   network_configuration {
     subnets          = ["${var.aws_subnets.subnet1}", "${var.aws_subnets.subnet2}", "${var.aws_subnets.subnet3}"]
     assign_public_ip = true
-    security_groups  = ["${module.alb.load_balancer_security_group}"]
+    security_groups  = ["${aws_security_group.service_security_group.id}"]
   }
 }
 


### PR DESCRIPTION
Corrigindo security group errado. O ECS service está com o security group do load balancer, por isso as requisições não funcionavam.